### PR TITLE
"Disable errors from golangci"

### DIFF
--- a/resources/.mega-linter.yml
+++ b/resources/.mega-linter.yml
@@ -56,6 +56,9 @@ ENABLE_LINTERS:
   - TERRAFORM_TERRAGRUNT
   - TERRAFORM_TERRAFORM_FMT
 
+DISABLE_ERRORS_LINTERS:
+  - GO_GOLANGCI_LINT
+
 # DISABLE:
 # - COPYPASTE # Uncomment to disable checks of excessive copy-pastes
 # - SPELL # Uncomment to disable checks of spelling mistakes


### PR DESCRIPTION
Summary:
GolangCI analysis will return a failure even though there are no lint errors, due to some arcane error. Issue is described in TDX-560. This change keeps the linter running, but prevents it from failing the lint as a whole.
Issue ID(s): TDX-560

Testing:
- [ ] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
