### PR TITLE
Add exceptions to ktlint

### DIFF
--- a/resources/.ktlint_editorconfig
+++ b/resources/.ktlint_editorconfig
@@ -1,0 +1,6 @@
+[*.{kt,kts}]
+ktlint_code_style = ktlint_official
+ktlint_standard_max-line-length = 160
+ktlint_standard = enabled
+ktlint_standard_multiline-expression-wrapping = disabled
+ktlint_standard_string-template-indent = disabled

--- a/resources/.mega-linter.yml
+++ b/resources/.mega-linter.yml
@@ -83,3 +83,13 @@ KOTLIN_DETEKT_ARGUMENTS:
     '--config',
     '/tmp/.detekt.yml'
   ]
+
+KOTLIN_KTLINT_PRE_COMMANDS:
+  [
+    command: 'wget https://raw.githubusercontent.com/elhub/devxp-lint-configuration/test-ktlint-config/resources/.ktlint_editorconfig -O /tmp/.ktlint_editorconfig'
+  ]
+
+KOTLIN_KTLINT_ARGUMENTS:
+  [
+    '--editorconfig=/tmp/.ktlint_editorconfig'
+  ]


### PR DESCRIPTION
This solves an issue where the the following format is illegal:

![image](https://github.com/user-attachments/assets/833a7951-a68c-4010-b70f-8fe7d929a8d0)
and is being corrected to this:
![image](https://github.com/user-attachments/assets/1ac94ce3-9c9e-4e3b-9d2a-59d8243867dc)


It also adds a `.ktlint_editorconfig` file which can be used to further customize ktlint.