### PR TITLE
Fix synchronization of editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,18 +11,43 @@ max_line_length = 160
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{java,kt,kts,scala,rs,xml,kt.spec,kts.spec}]
+[{.gitmodules}]
+indent_style = tab
+indent_size = 4
+
+[*.{java,scala,rs,xml}]
 indent_size = 4
 
 [*.{kt,kts}]
-ktlint_code_style = ktlint_official
+indent_size = 4
+ktlint_code_style = intellij_idea
 ktlint_standard_max-line-length = 160
 ktlint_standard = enabled
+
+ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than=unset
+ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
+ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than=unset
+ktlint_standard_string-template-indent = disabled
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_trailing-comma-on-declaration-site = disabled
+
+# These two rules are too strict on whether parameters can be on multiple lines even though they could potentially fit on one line.
+# Can't find a more specific rule to disable.
+ktlint_standard_function-signature = disabled
+ktlint_standard_class-signature = disabled
+
+# This ends up correcting to something that intellij auto-formats back
+ktlint_standard_condition-wrapping = disabled
+
+[{Makefile,**.mk}]
+# Use tabs for indentation (Makefiles require tabs)
+indent_style = tab
+indent_size = 4
 
 [{*.py, *.pyi}]
 indent_size = 4
 max_line_length = 160
 
-[{Makefile,**.mk}]
-# Use tabs for indentation (Makefiles require tabs)
+[{go.mod,go.sum,*.go}]
 indent_style = tab
+indent_size = 4

--- a/resources/.mega-linter.yml
+++ b/resources/.mega-linter.yml
@@ -46,7 +46,7 @@ ENABLE_LINTERS:
   - PYTHON_PYLINT
   - REPOSITORY_GIT_DIFF
   - REPOSITORY_GITLEAKS
-  - REPOSITORY_SEMLINT
+  - REPOSITORY_SECRETLINT
   #- REPOSITORY_SEMGREP
   #- REPOSITORY_TRIVY
   - SQL_SQL_LINT
@@ -76,6 +76,11 @@ FILEIO_REPORTER: false
 # Uncomment if you want MegaLinter to detect errors but not block CI to pass
 # DISABLE_ERRORS: true
 
+# Ensure EditorConfig is up to date
+PRE_COMMANDS:
+  - command: 'wget https://raw.githubusercontent.com/elhub/devxp-project-template/refs/heads/main/resources/.editorconfig-template -O ./.editorconfig'
+    cwd: workspace
+
 # GOLANGCI_LINT configuration
 GO_GOLANGCI_LINT_ARGUMENTS: ['run', './...']
 
@@ -93,9 +98,10 @@ KOTLIN_DETEKT_ARGUMENTS:
 
 KOTLIN_KTLINT_PRE_COMMANDS:
   [
-    command: 'wget https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/.ktlint_editorconfig -O /tmp/.ktlint_editorconfig'
+    command: 'wget https://raw.githubusercontent.com/elhub/devxp-project-template/refs/heads/main/resources/.editorconfig-template -O /tmp/.ktlint_editorconfig'
   ]
 
 KOTLIN_KTLINT_ARGUMENTS:
   ['--editorconfig=/tmp/.ktlint_editorconfig']
+
 # REPOSITORY_SEMGREP_RULESETS: ["p/default","p/owasp-top-ten"]


### PR DESCRIPTION
## 📝 Description

This ensures that the editorconfig is continually being updated to match the official editorconfig. It also ensures that ktlint is using the same editorconfig.

It might be possible to remove the download step in ktlint, but for now it is left as is.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
