### PR TITLE
Pass checkstyle config path using direct arguments

### DIFF
--- a/resources/.mega-linter.yml
+++ b/resources/.mega-linter.yml
@@ -109,7 +109,7 @@ JAVA_CHECKSTYLE_PRE_COMMANDS:
   [
     command: 'curl https://raw.githubusercontent.com/elhub/devxp-lint-configuration/main/resources/checkstyle-config.xml -o /tmp/checkstyle-config.xml'
   ]
-JAVA_CHECKSTYLE_CONFIG_FILE: 'checkstyle-config.xml'
+JAVA_CHECKSTYLE_ARGUMENTS: -c /tmp/checkstyle-config.xml
 
 JAVA_PMD_PRE_COMMANDS:
   [


### PR DESCRIPTION
Using the JAVA_CHECKSTYLE_CONFIG_FILE parameter seems to be causing some weird behaviour in which the file path is not correctly passed _some of the time_.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
