### PR TITLE
fix: ignore gradlew.bat from linting

### DIFF
--- a/resources/.ecrc
+++ b/resources/.ecrc
@@ -16,3 +16,8 @@
     "MaxLineLength": true
   }
 }
+{
+    "exclude": [
+    "**/gradlew.bat"
+    ]
+}


### PR DESCRIPTION
## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
