### PR TITLE
fix: update to use correct params this time

### DIFF
--- a/resources/.detekt.yml
+++ b/resources/.detekt.yml
@@ -10,11 +10,11 @@ complexity:
   active: true
   TooManyFunctions:
     active: true
-    functionThreshold: 20
-    constructorThreshold: 20
+    thresholdInFiles: 20
   LongMethod:
     active: true
-    threshold: 120
+    functionThreshold: 120
+    constructorThreshold: 120
   LongParameterList:
     active: true
     threshold: 8


### PR DESCRIPTION
## 📝 Description

Apparently the deprecation messages provided were incorrect. Corrected per the docs instead

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
